### PR TITLE
Change Facebook SDK Dependency from 3.10 to 3.20

### DIFF
--- a/HIPSocialAuth.podspec
+++ b/HIPSocialAuth.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '7.0'
   s.source_files = 'HIPSocialAuth/*.{h,m}', 'Dependencies/*/*.{h,m}'
   s.requires_arc = true
-  s.dependency 'Facebook-iOS-SDK', '~> 3.10.0'
+  s.dependency 'Facebook-iOS-SDK', '~> 3.20.0'
 end


### PR DESCRIPTION
Facebook iOS SDK 3.10 raises build errors on iOS 8, hence the change.
