### PR TITLE
Change Facebook SDK dependency requirement

### DIFF
--- a/HIPSocialAuth.podspec
+++ b/HIPSocialAuth.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '7.0'
   s.source_files = 'HIPSocialAuth/*.{h,m}', 'Dependencies/*/*.{h,m}'
   s.requires_arc = true
-  s.dependency 'Facebook-iOS-SDK', '~> 3.10.0'
+  s.dependency 'Facebook-iOS-SDK', '~> 3.10'
 end


### PR DESCRIPTION
Facebook SDK 3.10 gives build errors on iOS 8, hence the change from point
updates for v3.10 to point updates for 3 after 3.10
